### PR TITLE
Revert "fix(deps): bump @ng-icons/core from 13.3.0 to 14.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "~13.2.3",
     "@angular/platform-browser-dynamic": "~13.2.3",
     "@angular/router": "~13.2.3",
-    "@ng-icons/core": "^14.1.0",
+    "@ng-icons/core": "^13.3.0",
     "@ng-icons/heroicons": "^13.3.0",
     "@ngneat/tailwind": "^7.0.3",
     "headlessui-angular": "0.0.5",


### PR DESCRIPTION
Reverts gnugomez/bfast-client#94

Breaking changes to solve, i will do it manually